### PR TITLE
Rename package to github.com/mathaou/termdbms

### DIFF
--- a/database/query.go
+++ b/database/query.go
@@ -35,7 +35,7 @@ type Database interface {
 }
 
 type Update struct {
-	v    map[string]interface{} // these are anchors to ensure the right row/col gets updated
+	v         map[string]interface{} // these are anchors to ensure the right row/col gets updated
 	Column    string                 // this is the header
 	Update    interface{}            // this is the new cell value
 	TableName string

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module termdbms
+module github.com/mathaou/termdbms
 
 go 1.16
 

--- a/list/style.go
+++ b/list/style.go
@@ -2,7 +2,7 @@ package list
 
 import (
 	"github.com/charmbracelet/lipgloss"
-	"termdbms/tuiutil"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 const (

--- a/main.go
+++ b/main.go
@@ -4,18 +4,20 @@ import (
 	"database/sql"
 	"flag"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/termenv"
 	"io/fs"
 	"io/ioutil"
-	_ "modernc.org/sqlite"
 	"os"
 	"path/filepath"
 	"strings"
-	"termdbms/database"
-	. "termdbms/tuiutil"
-	. "termdbms/viewer"
+
+	. "github.com/mathaou/termdbms/tuiutil"
+	. "github.com/mathaou/termdbms/viewer"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mathaou/termdbms/database"
+	"github.com/muesli/termenv"
+	_ "modernc.org/sqlite"
 )
 
 type DatabaseType string
@@ -102,7 +104,7 @@ func main() {
 			return nil
 		})
 	} else {
-		os.Mkdir(HiddenTmpDirectoryName, 0777)
+		os.Mkdir(HiddenTmpDirectoryName, 0o777)
 	}
 
 	database.IsCSV = strings.HasSuffix(path, ".csv")

--- a/tuiutil/theme.go
+++ b/tuiutil/theme.go
@@ -12,7 +12,6 @@ const (
 	TextColorKey                = "TextColor"
 )
 
-
 // styling functions
 var (
 	Highlight = func() string {

--- a/viewer/defs.go
+++ b/viewer/defs.go
@@ -4,13 +4,13 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"termdbms/database"
-	"termdbms/list"
+	"github.com/mathaou/termdbms/database"
+	"github.com/mathaou/termdbms/list"
 )
 
 type SQLSnippet struct {
 	Query string `json:"Query"`
-	Name string `json:"Name"`
+	Name  string `json:"Name"`
 }
 
 type ScrollData struct {

--- a/viewer/events.go
+++ b/viewer/events.go
@@ -3,13 +3,14 @@ package viewer
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"os"
-	"termdbms/list"
-	"termdbms/tuiutil"
-	"time"
+	"github.com/mathaou/termdbms/list"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 // HandleMouseEvents does that

--- a/viewer/global.go
+++ b/viewer/global.go
@@ -2,11 +2,12 @@ package viewer
 
 import (
 	"fmt"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"strings"
-	"termdbms/database"
-	"termdbms/tuiutil"
+	"github.com/mathaou/termdbms/database"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 type Command func(m *TuiModel) tea.Cmd

--- a/viewer/lineedit.go
+++ b/viewer/lineedit.go
@@ -8,9 +8,10 @@ import (
 	"math/rand"
 	"os"
 	"strings"
-	"termdbms/database"
-	"termdbms/tuiutil"
 	"time"
+
+	"github.com/mathaou/termdbms/database"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 const (
@@ -128,7 +129,7 @@ func EditEnter(m *TuiModel) {
 			return
 		} else if input == ":clip" {
 			ExitToDefaultView(m)
-			if len( m.ClipboardList.Items()) == 0 {
+			if len(m.ClipboardList.Items()) == 0 {
 				return
 			}
 			m.UI.ShowClipboard = true
@@ -186,14 +187,14 @@ func EditEnter(m *TuiModel) {
 				}
 				m.Clipboard = append(m.Clipboard, SQLSnippet{
 					Query: input,
-					Name: title,
+					Name:  title,
 				})
 				b, _ := json.Marshal(m.Clipboard)
 				snippetsFile := fmt.Sprintf("%s/%s", HiddenTmpDirectoryName, SQLSnippetsFile)
 				f, _ := os.OpenFile(snippetsFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0775)
 				f.Write(b)
 				f.Close()
-				m.WriteMessage(fmt.Sprintf("Wrote SQL snippet %s to %s. Total count is %d", title, snippetsFile, len(m.ClipboardList.Items()) + 1))
+				m.WriteMessage(fmt.Sprintf("Wrote SQL snippet %s to %s. Total count is %d", title, snippetsFile, len(m.ClipboardList.Items())+1))
 			}
 			m.TextInput.Model.SetValue("")
 		}

--- a/viewer/mode.go
+++ b/viewer/mode.go
@@ -1,8 +1,9 @@
 package viewer
 
 import (
-	tea "github.com/charmbracelet/bubbletea"
 	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 var (

--- a/viewer/modelutil.go
+++ b/viewer/modelutil.go
@@ -4,12 +4,13 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
 	"os"
 	"strings"
-	"termdbms/database"
-	"termdbms/list"
-	"termdbms/tuiutil"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/mathaou/termdbms/database"
+	"github.com/mathaou/termdbms/list"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 func (m *TuiModel) WriteMessage(s string) {

--- a/viewer/serialize.go
+++ b/viewer/serialize.go
@@ -8,7 +8,8 @@ import (
 	"os"
 	"path"
 	"strings"
-	"termdbms/database"
+
+	"github.com/mathaou/termdbms/database"
 )
 
 var (

--- a/viewer/snippets.go
+++ b/viewer/snippets.go
@@ -2,12 +2,13 @@ package viewer
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"io"
 	"strings"
-	"termdbms/list"
-	"termdbms/tuiutil"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mathaou/termdbms/list"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 var (
@@ -50,7 +51,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 	str := fmt.Sprintf("%d) %s%s | ", index+1, strings.Repeat(" ", digits-incomingDigits),
 		i.Title())
-	query := localStyle.Render(i.Query[0:Min(TUIWidth - 10, Max(len(i.Query) - 1, len(i.Query) - 1 - len(str)))]) // padding + tab + padding
+	query := localStyle.Render(i.Query[0:Min(TUIWidth-10, Max(len(i.Query)-1, len(i.Query)-1-len(str)))]) // padding + tab + padding
 	str += strings.ReplaceAll(query, "\n", "")
 
 	localStyle = style.Copy().PaddingLeft(4)
@@ -67,7 +68,7 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 
 			return lipgloss.JoinHorizontal(lipgloss.Left,
 				localStyle.
-				Render("> "),
+					Render("> "),
 				style.Render(s))
 		}
 	}

--- a/viewer/table.go
+++ b/viewer/table.go
@@ -2,12 +2,13 @@ package viewer
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"strings"
-	"termdbms/database"
-	"termdbms/tuiutil"
-	"time"
+	"github.com/mathaou/termdbms/database"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 type TableAssembly func(m *TuiModel, s *string, c *chan bool)

--- a/viewer/tableutil.go
+++ b/viewer/tableutil.go
@@ -2,8 +2,9 @@ package viewer
 
 import (
 	"errors"
+
 	"github.com/charmbracelet/lipgloss"
-	"termdbms/tuiutil"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 var maxHeaders int

--- a/viewer/ui.go
+++ b/viewer/ui.go
@@ -2,13 +2,14 @@ package viewer
 
 import (
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/muesli/reflow/wordwrap"
 	"strconv"
 	"strings"
-	"termdbms/tuiutil"
 	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mathaou/termdbms/tuiutil"
+	"github.com/muesli/reflow/wordwrap"
 )
 
 var (

--- a/viewer/util.go
+++ b/viewer/util.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/charmbracelet/lipgloss"
 	"hash/fnv"
 	"io"
 	"math/rand"
@@ -15,11 +14,13 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 const (
 	HiddenTmpDirectoryName = ".termdbms"
-	SQLSnippetsFile = "snippets.termdbms"
+	SQLSnippetsFile        = "snippets.termdbms"
 )
 
 func TruncateIfApplicable(m *TuiModel, conv string) (s string) {

--- a/viewer/viewer.go
+++ b/viewer/viewer.go
@@ -2,10 +2,11 @@ package viewer
 
 import (
 	"fmt"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"termdbms/list"
-	"termdbms/tuiutil"
+	"github.com/mathaou/termdbms/list"
+	"github.com/mathaou/termdbms/tuiutil"
 )
 
 var (
@@ -153,7 +154,7 @@ func (m TuiModel) View() string {
 	}(&content)
 
 	if m.UI.ShowClipboard {
-		<- done
+		<-done
 		return content
 	}
 


### PR DESCRIPTION
`go install` is a default way to install binaries with the modern version of go. But the current package is not compatible with it.

Here is my attempt
<img width="1103" alt="Screenshot 2022-04-15 at 13 06 09" src="https://user-images.githubusercontent.com/4927633/163558434-afd13ff1-5b06-4479-affe-dbef441d6863.png">

The error is straightforward. I just update `go mod` and replace imports (with `go imports` that because of some reformats).

I don't update README.md instruction, if you consider that required, I'll do it.